### PR TITLE
GitHub Action to deploy on Tagged release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,23 @@
+
+name: CI
+
+on:
+  push:
+    tags:
+    - "*"
+
+jobs:
+  tag:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Build
+      run: |
+        echo "No actions, this plugin is simple"
+    - name: WordPress Plugin Deploy
+      uses: 10up/action-wordpress-plugin-deploy@master
+      env:
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        SLUG: cd2-fullstory-integration


### PR DESCRIPTION
Deploying WordPress plugins is a PITA. GitHub actions from 10up make this less so