### PR TITLE
1.0.8 Features

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -1,0 +1,17 @@
+(function() {
+    /*
+    * Helper to extract FullStory Org code from URL
+    */
+    const SCHEME_INDICATOR = '://';
+    const URL_PATH_SEPARATOR = '/';
+    const FULLSTORY_DOMAIN_INDICATOR = 'app.fullstory.com';
+    
+    document.querySelector('#fullstory_org_code').addEventListener('input', function(event) {
+        const curInput = event.target;
+        const curValue = curInput.value;
+        if (curValue.includes(SCHEME_INDICATOR) && curValue.includes(FULLSTORY_DOMAIN_INDICATOR)) {
+            const urlParts = curValue.split(URL_PATH_SEPARATOR);
+            curInput.value = urlParts.length > 5 ? urlParts[4] : curValue;
+        }
+    });
+})();

--- a/js/fs-snippet.js
+++ b/js/fs-snippet.js
@@ -1,0 +1,20 @@
+window['_fs_host'] = 'fullstory.com';
+window['_fs_script'] = 'edge.fullstory.com/s/fs.js';
+window['_fs_namespace'] = 'FS';
+(function(m,n,e,t,l,o,g,y){
+    if (e in m) {if(m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].');} return;}
+    g=m[e]=function(a,b,s){g.q?g.q.push([a,b,s]):g._api(a,b,s);};g.q=[];
+    o=n.createElement(t);o.async=1;o.crossOrigin='anonymous';o.src='https://'+_fs_script;
+    y=n.getElementsByTagName(t)[0];y.parentNode.insertBefore(o,y);
+    g.identify=function(i,v,s){g(l,{uid:i},s);if(v)g(l,v,s)};g.setUserVars=function(v,s){g(l,v,s)};g.event=function(i,v,s){g('event',{n:i,p:v},s)};
+    g.anonymize=function(){g.identify(!!0)};
+    g.shutdown=function(){g("rec",!1)};g.restart=function(){g("rec",!0)};
+    g.log = function(a,b){g("log",[a,b])};
+    g.consent=function(a){g("consent",!arguments.length||a)};
+    g.identifyAccount=function(i,v){o='account';v=v||{};v.acctId=i;g(o,v)};
+    g.clearUserCookie=function(){};
+    g.setVars=function(n, p){g('setVars',[n,p]);};
+    g._w={};y='XMLHttpRequest';g._w[y]=m[y];y='fetch';g._w[y]=m[y];
+    if(m[y])m[y]=function(){return g._w[y].apply(this,arguments)};
+    g._v="1.3.0";
+})(window,document,window['_fs_namespace'],'script','user');

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: LewisCowles,CD2Team
 Tags: integrate, integration, ux, user experience, user-experience, fullstory, cd2, codesign2, lewiscowles, user behaviour, user recording, metrics, user insight, woocommerce analytics, woocommerce monitoring, customer profile, replay user session
 Requires at least: 4.6
-Tested up to: 5.3.2
+Tested up to: 5.7.0
 Requires PHP: 5.6
-Stable tag: 1.0.7
+Stable tag: 1.0.8
 License: GPLv3
 
 == Description ==
@@ -24,13 +24,45 @@ The plugin does no special work apart from ensuring that attributes are escaped 
 
 Care has been taken to supply the following filters, so that you can specify your own custom fullstory attributes.
 
-* cd2_fstory_data
+* cd2_fstory_data (array)
 
 If using custom filters, please note you are wholely responsible for not messing things up. I recommend using a sibling plugin rather than editing this one; as well as testing locally, perhaps in staging before deploying to production as FullStory does not love malformed data. The format of data is simply key-value in a PHP array which is merged with the default array.
 
 This is a reference plugin, I'd love to develop it further, or work with you or your business to include additional features, perhaps a hooks interface or more formal view-separation for complex projects. I've used this on Multisite, Standard WP, multi-lingual sites.
 
 == Changelog ==
+= 1.0.8 =
+**Added**
+
+* Hook `cd2_enable_fstory` which allows custom plugins to disable the fullstory integration by returning false from filter. It's true by default. Just deactivate the plugin if you don't want to use.
+* Hook `cd2_disable_fstory_admin` which allows custom plugins to enable fullstory integration in the admin area by returning true from filter. Importantly, `cd2_enable_fstory` also needs to be true.
+* Hook `cd2_fstory_debug_enable` which allows custom plugins to enable debug mode by returning true from filter.
+* Hook `cd2_fstory_snippet` allows custom plugins to enable using alternative JavaScript when integrating with FullStory.
+* Ability to edit FullStory plugin JavaScript using files (source control vs database call) by editing the plugin or creating a `snippet.js` within a `fullstory` directory, inside your `wp-content` direcotry.
+
+**Changed**
+
+* Reported WordPress compatibility (after tests).
+* Disabling logic.
+* Plugin source code (following moving to the CD2 org)
+
+**Fixed**
+
+* N/A
+
+= 1.0.7 =
+**Added**
+
+* N/A
+
+**Changed**
+
+Reported WordPress compatibility (after tests)
+
+**Fixed**
+
+* N/A
+
 = 1.0.6 =
 **Added**
 


### PR DESCRIPTION
**Added**

* Hook `cd2_enable_fstory` which allows custom plugins to disable the fullstory integration by returning false from filter. It's true by default. Just deactivate the plugin if you don't want to use.
* Hook `cd2_disable_fstory_admin` which allows custom plugins to enable fullstory integration in the admin area by returning true from filter. Importantly, `cd2_enable_fstory` also needs to be true.
* Hook `cd2_fstory_debug_enable` which allows custom plugins to enable debug mode by returning true from filter.
* Hook `cd2_fstory_snippet` allows custom plugins to enable using alternative JavaScript when integrating with FullStory.
* Ability to edit FullStory plugin JavaScript using files (source control vs database call) by editing the plugin or creating a `snippet.js` within a `fullstory` directory, inside your `wp-content` direcotry.

**Changed**

* Reported WordPress compatibility (after tests).
* Disabling logic.
* Plugin source code (following moving to the CD2 org)

**Fixed**

* N/A
